### PR TITLE
修复PsiClass获取全限定报名错误的问题,该问题导致无法取得特定包下的类(破坏了智能提示)

### DIFF
--- a/idea-plugin/src/main/kotlin/me/danwi/sqlex/idea/util/extension/PsiClass.kt
+++ b/idea-plugin/src/main/kotlin/me/danwi/sqlex/idea/util/extension/PsiClass.kt
@@ -2,6 +2,6 @@ package me.danwi.sqlex.idea.util.extension
 
 import com.intellij.psi.PsiClass
 
-//获取权限定包名
+//获取全限定包名
 val PsiClass.qualifiedPackageName: String?
-    inline get() = this.qualifiedName?.removePrefix(".${this.name}")
+    inline get() = this.qualifiedName?.removeSuffix(".${this.name}")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7589835/162355152-38044346-8c83-4440-8b84-f47a02bf1e15.png)
