### PR TITLE
增加日志模块

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     compileOnly 'org.springframework:spring-tx:5.3.18'
     compileOnly 'org.springframework:spring-context:5.3.18'
     compileOnly 'mysql:mysql-connector-java:8.0.28'
+    // 日志
+    implementation 'org.slf4j:slf4j-api:1.7.36'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"

--- a/core/src/main/java/me/danwi/sqlex/core/logging/Log.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/Log.java
@@ -1,0 +1,22 @@
+package me.danwi.sqlex.core.logging;
+
+/**
+ * SqlEx 日志接口
+ */
+public interface Log {
+    boolean isDebugEnabled();
+
+    boolean isTraceEnabled();
+
+    void info(String msg);
+
+    void error(String s, Throwable e);
+
+    void error(String s);
+
+    void debug(String s);
+
+    void trace(String s);
+
+    void warn(String s);
+}

--- a/core/src/main/java/me/danwi/sqlex/core/logging/LogException.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/LogException.java
@@ -1,0 +1,29 @@
+package me.danwi.sqlex.core.logging;
+
+
+import me.danwi.sqlex.core.exception.SqlExException;
+
+/**
+ * SqlEx日志异常
+ */
+public class LogException extends SqlExException {
+
+    private static final long serialVersionUID = -1644142198794818725L;
+
+    public LogException() {
+        super();
+    }
+
+    public LogException(String message) {
+        super(message);
+    }
+
+    public LogException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LogException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/core/src/main/java/me/danwi/sqlex/core/logging/LogFactory.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/LogFactory.java
@@ -1,0 +1,60 @@
+package me.danwi.sqlex.core.logging;
+
+import me.danwi.sqlex.core.logging.slf4j.Slf4jImpl;
+import me.danwi.sqlex.core.logging.stdout.StdOutImpl;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * SqlEx 日志工厂，SqlEx框架内部使用
+ */
+public final class LogFactory {
+
+    private static Constructor<? extends Log> logConstructor;
+
+    static {
+        tryImplementation(LogFactory::useSlf4jLogging);
+        tryImplementation(LogFactory::useStdOutLogging);
+    }
+
+    public static Log getLog(Class<?> clazz) {
+        return getLog(clazz.getName());
+    }
+
+    public static Log getLog(String logger) {
+        try {
+            return logConstructor.newInstance(logger);
+        } catch (Throwable t) {
+            throw new LogException("错误创建 logger： " + logger + ".  由于: " + t, t);
+        }
+    }
+
+    public static synchronized void useSlf4jLogging() {
+        setImplementation(Slf4jImpl.class);
+    }
+
+    public static synchronized void useStdOutLogging() {
+        setImplementation(StdOutImpl.class);
+    }
+
+    public static void tryImplementation(Runnable runnable) {
+        if (logConstructor == null) {
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                // ignore
+            }
+        }
+    }
+
+    public static void setImplementation(Class<? extends Log> implClass) {
+        try {
+            Constructor<? extends Log> candidate = implClass.getConstructor(String.class);
+            Log log = candidate.newInstance(LogFactory.class.getName());
+            log.debug("使用 '" + implClass + "' 适配器 初始化 日志工厂");
+            logConstructor = candidate;
+        } catch (Throwable t) {
+            throw new LogException("错误创建日志工厂实现.  由于: " + t, t);
+        }
+    }
+}

--- a/core/src/main/java/me/danwi/sqlex/core/logging/package-info.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * 框架日志入口包
+ */
+package me.danwi.sqlex.core.logging;

--- a/core/src/main/java/me/danwi/sqlex/core/logging/slf4j/Slf4jImpl.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/slf4j/Slf4jImpl.java
@@ -1,0 +1,62 @@
+package me.danwi.sqlex.core.logging.slf4j;
+
+import me.danwi.sqlex.core.logging.Log;
+import me.danwi.sqlex.core.logging.LogException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
+
+/**
+ * Slf4j实现
+ */
+public class Slf4jImpl implements Log {
+
+    private Logger logger;
+
+    public Slf4jImpl(String clazz) {
+        logger = LoggerFactory.getLogger(clazz);
+        if (logger instanceof NOPLogger) {
+            throw new LogException("无法获取有效Slf4j日志实例");
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    @Override
+    public void error(String s, Throwable e) {
+        logger.error(s, e);
+    }
+
+    @Override
+    public void error(String s) {
+        logger.error(s);
+    }
+
+    @Override
+    public void debug(String s) {
+        logger.debug(s);
+    }
+
+    @Override
+    public void trace(String s) {
+        logger.trace(s);
+    }
+
+    @Override
+    public void warn(String s) {
+        logger.warn(s);
+    }
+}

--- a/core/src/main/java/me/danwi/sqlex/core/logging/stdout/StdOutImpl.java
+++ b/core/src/main/java/me/danwi/sqlex/core/logging/stdout/StdOutImpl.java
@@ -1,0 +1,59 @@
+package me.danwi.sqlex.core.logging.stdout;
+
+import me.danwi.sqlex.core.logging.Log;
+
+public class StdOutImpl implements Log {
+
+    private String clazz;
+
+    public StdOutImpl(String clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return true;
+    }
+
+    @Override
+    public void info(String msg) {
+        System.out.println(clazz + ": " + msg);
+    }
+
+    @Override
+    public void error(String s, Throwable e) {
+        if (isTraceEnabled()) {
+            System.err.println(clazz + ": " + s);
+            e.printStackTrace(System.err);
+        }
+    }
+
+    @Override
+    public void error(String s) {
+        if (isTraceEnabled()) {
+            System.err.println(clazz + ": " + s);
+        }
+    }
+
+    @Override
+    public void debug(String s) {
+        if (isDebugEnabled()) {
+            System.out.println(clazz + ": " + s);
+        }
+    }
+
+    @Override
+    public void trace(String s) {
+        System.out.println(clazz + ": " + s);
+    }
+
+    @Override
+    public void warn(String s) {
+        System.out.println(clazz + ": " + s);
+    }
+}

--- a/core/src/test/java/me/danwi/sqlex/core/logging/LogTest.java
+++ b/core/src/test/java/me/danwi/sqlex/core/logging/LogTest.java
@@ -1,0 +1,18 @@
+package me.danwi.sqlex.core.logging;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author wjy
+ */
+public class LogTest {
+
+    @Test
+    public void test() {
+        final Log log = LogFactory.getLog(LogTest.class);
+
+        log.info("test");
+        log.debug("test debug");
+        log.error("test error", new LogException("test error"));
+    }
+}


### PR DESCRIPTION
1. 定义基础日志接口，日志工厂
2. 提供Slf4j日志适配器，提供控制台输出日志适配器，如果没有具体Slf4j实现，则使用控制台日志适配器
3. 日志工厂提供使用自定义日志实现接口`setImplementation`